### PR TITLE
hot-fix/dnp3-python-change-classname

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 volttron = ">=10.0.2rc0"
-dnp3-python = ">=0.2.3b3"
+dnp3-python = ">=0.2.3b3, <0.3.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
### Description:
From User:
"""
can you look at this https://github.com/eclipse-volttron/volttron-dnp3-outstation/actions/runs/4961666407/jobs/8878743363
what steps are missing to make the run test work properly
"""

### Investigation:
Note "E   ModuleNotFoundError: No module named 'dnp3_python.dnp3station.outstation_new'"  from https://github.com/eclipse-volttron/volttron-dnp3-outstation/actions/runs/4961666407/jobs/8878743363#step:17:56

Which is caused by dnp3-python package change classname since 0.3.0, referencing issue: [Backward compatibility within major viersion (after changing the classname from MyOutStationNew to MyOutStation)](https://github.com/VOLTTRON/dnp3-python/issues/44)

### Solution
Currently, pin to dnp3-python>=0.2.3 < 0.3.0 


